### PR TITLE
API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Decrypt ciphertexts (encrypted segments) `ciphertexts` using 32-byte hex encoded
 a 32-byte hex encoded scalar.
 
 #### `ve.prove(encryptionKeyHex: string, encryptionResult: EncryptionResult): Proof`
-Prove the encryption of a discrete logarithm under a 64-byte hex encoded EC public key `encryptionKeyHex`.
+Prove that `encryptionResult` is an encryption of a discrete logarithm under a 64-byte hex encoded EC public key `encryptionKeyHex`.
 
 #### `ve.verify(proof: Proof, encryptionKeyHex: string, publicKeyHex: string, ciphertexts: Helgamalsegmented): boolean`
 Verify that `proof` proves that `ciphertexts` are a result of an encryption of a discrete logarithm of a 64-byte hex encoded EC public key `publicKeyHex` under the 64-byte hex encoded EC public key `encryptionKeyHex`

--- a/README.md
+++ b/README.md
@@ -72,6 +72,45 @@ Prove that `encryptionResult` is an encryption of a discrete logarithm under a 6
 #### `ve.verify(proof: Proof, encryptionKeyHex: string, publicKeyHex: string, ciphertexts: Helgamalsegmented): boolean`
 Verify that `proof` proves that `ciphertexts` are a result of an encryption of a discrete logarithm of a 64-byte hex encoded EC public key `publicKeyHex` under the 64-byte hex encoded EC public key `encryptionKeyHex`
 
+## Example
+
+```js
+import ve from 'dlog-verifiable-enc';
+import {ec as EC} from 'elliptic';
+const ec = new EC('secp256k1');
+import assert from 'assert';
+
+// generate encryption/decryption EC key pair
+const encKeyPair = ec.genKeyPair();
+const decryptionKeyHex = encKeyPair
+    .getPrivate()
+    .toBuffer()
+    .toString('hex');
+const encryptionKeyHex = encKeyPair
+     .getPublic()
+     .encode('hex', false)
+     .substr(2);  // (x,y);
+
+// generate EC key pair (the discrete logarithm to be encrypted)
+const keyPair = ec.genKeyPair();
+const secretKeyHex = keyPair
+    .getPrivate()
+    .toBuffer()
+    .toString('hex');
+const publicKeyHex = keyPair
+    .getPublic()
+    .encode('hex', false)
+    .substr(2);  // (x,y)
+
+const encryptionResult = ve.encrypt(encryptionKeyHex, secretKeyHex);
+const secretKeyHexNew = ve.decrypt(decryptionKeyHex, encryptionResult.ciphertexts);
+assert(secretKeyHexNew === secretKeyHex);
+
+const proof = ve.prove(encryptionKeyHex, encryptionResult);
+const isVerified = ve.verify(proof, encryptionKeyHex, publicKeyHex, encryptionResult.ciphertexts);
+assert(isVerified);
+```
+
 ## Contact
 
 Feel free to [reach out](mailto:github@kzencorp.com) or join the KZen Research [Telegram](https://t.me/kzen_research) for discussions on code and research.

--- a/README.md
+++ b/README.md
@@ -59,18 +59,18 @@ Composed of the following structure:
 }
 ```
 
-#### `ve.encrypt(encryptionKeyHex: string, secretHex: string): EncryptionResult` 
-Encrypt a 32-byte hex encoded scalar `secretHex` using 64-byte hex encoded EC public key `encryptionKeyHex`. 
+#### `ve.encrypt(encryptionKey: Buffer, secret: Buffer): EncryptionResult` 
+Encrypt a 32-byte scalar `secret` using 64-byte EC public key `encryptionKey`. 
 
-#### `ve.decrypt(decryptionKeyHex: string, ciphertexts: Helgamalsegmented): string`
-Decrypt ciphertexts (encrypted segments) `ciphertexts` using 32-byte hex encoded scalar `decryptionKeyHex` to get
-a 32-byte hex encoded scalar.
+#### `ve.decrypt(decryptionKey: Buffer, ciphertexts: Helgamalsegmented): Buffer`
+Decrypt ciphertexts (encrypted segments) `ciphertexts` using 32-byte scalar `decryptionKey` to get
+a 32-byte scalar.
 
-#### `ve.prove(encryptionKeyHex: string, encryptionResult: EncryptionResult): Proof`
-Prove that `encryptionResult` is an encryption of a discrete logarithm under a 64-byte hex encoded EC public key `encryptionKeyHex`.
+#### `ve.prove(encryptionKey: Buffer, encryptionResult: EncryptionResult): Proof`
+Prove that `encryptionResult` is an encryption of a discrete logarithm under a 64-byte EC public key `encryptionKey`.
 
-#### `ve.verify(proof: Proof, encryptionKeyHex: string, publicKeyHex: string, ciphertexts: Helgamalsegmented): boolean`
-Verify that `proof` proves that `ciphertexts` are a result of an encryption of a discrete logarithm of a 64-byte hex encoded EC public key `publicKeyHex` under the 64-byte hex encoded EC public key `encryptionKeyHex`
+#### `ve.verify(proof: Proof, encryptionKey: Buffer, publicKey: Buffer, ciphertexts: Helgamalsegmented): boolean`
+Verify that `proof` proves that `ciphertexts` are a result of an encryption of a discrete logarithm of a 64-byte EC public key `publicKey` under the 64-byte  EC public key `encryptionKey`
 
 ## Example
 
@@ -82,32 +82,34 @@ import assert from 'assert';
 
 // generate encryption/decryption EC key pair
 const encKeyPair = ec.genKeyPair();
-const decryptionKeyHex = encKeyPair
+const decryptionKey = encKeyPair
     .getPrivate()
-    .toBuffer()
-    .toString('hex');
-const encryptionKeyHex = encKeyPair
-     .getPublic()
-     .encode('hex', false)
-     .substr(2);  // (x,y);
+    .toBuffer();
+const encryptionKey = Buffer.from(
+    encKeyPair
+        .getPublic()
+        .encode('hex', false)
+        .substr(2),  // (x,y);
+    'hex');
 
 // generate EC key pair (the discrete logarithm to be encrypted)
 const keyPair = ec.genKeyPair();
-const secretKeyHex = keyPair
+const secretKey = keyPair
     .getPrivate()
-    .toBuffer()
-    .toString('hex');
-const publicKeyHex = keyPair
-    .getPublic()
-    .encode('hex', false)
-    .substr(2);  // (x,y)
+    .toBuffer();
+const publicKey = Buffer.from(
+    keyPair
+        .getPublic()
+        .encode('hex', false)
+        .substr(2),  // (x,y)
+    'hex');
 
-const encryptionResult = ve.encrypt(encryptionKeyHex, secretKeyHex);
-const secretKeyHexNew = ve.decrypt(decryptionKeyHex, encryptionResult.ciphertexts);
-assert(secretKeyHexNew === secretKeyHex);
+const encryptionResult = ve.encrypt(encryptionKey, secretKey);
+const secretKeyNew = ve.decrypt(decryptionKey, encryptionResult.ciphertexts);
+assert(secretKeyNew.equals(secretKey));
 
-const proof = ve.prove(encryptionKeyHex, encryptionResult);
-const isVerified = ve.verify(proof, encryptionKeyHex, publicKeyHex, encryptionResult.ciphertexts);
+const proof = ve.prove(encryptionKey, encryptionResult);
+const isVerified = ve.verify(proof, encryptionKey, publicKey, encryptionResult.ciphertexts);
 assert(isVerified);
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Encrypt a 32-byte hex encoded scalar `secretHex` using 64-byte hex encoded EC pu
 
 #### `ve.decrypt(decryptionKeyHex: string, ciphertexts: Helgamalsegmented): string`
 Decrypt ciphertexts (encrypted segments) `ciphertexts` using 32-byte hex encoded scalar `decryptionKeyHex` to get
-a 32-byte scalar.
+a 32-byte hex encoded scalar.
 
 #### `ve.prove(encryptionKeyHex: string, encryptionResult: EncryptionResult): Proof`
 Prove the encryption of a discrete logarithm under a 64-byte hex encoded EC public key `encryptionKeyHex`.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ Run the verifer of all the zk proofs. Accept only if all value to true
 
 The encryption is done segment-by-segment which enables also a use case of fair swap of secrets. 
 
+## API
+
+#### `interface EncryptionResult`
+Composed of the following structure:
+```
+{
+    witness: Witness,
+    ciphertexts: Helgamalsegmented
+}
+```
+
+#### `ve.encrypt(encryptionKeyHex: string, secretHex: string): EncryptionResult` 
+Encrypt a 32-byte hex encoded scalar `secretHex` using 64-byte hex encoded EC public key `encryptionKeyHex`. 
+
+#### `ve.decrypt(decryptionKeyHex: string, ciphertexts: Helgamalsegmented): string`
+Decrypt ciphertexts (encrypted segments) `ciphertexts` using 32-byte hex encoded scalar `decryptionKeyHex` to get
+a 32-byte scalar.
+
+#### `ve.prove(encryptionKeyHex: string, encryptionResult: EncryptionResult): Proof`
+Prove the encryption of a discrete logarithm under a 64-byte hex encoded EC public key `encryptionKeyHex`.
+
+#### `ve.verify(proof: Proof, encryptionKeyHex: string, publicKeyHex: string, ciphertexts: Helgamalsegmented): boolean`
+Verify that `proof` proves that `ciphertexts` are a result of an encryption of a discrete logarithm of a 64-byte hex encoded EC public key `publicKeyHex` under the 64-byte hex encoded EC public key `encryptionKeyHex`
 
 ## Contact
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-rust": "neon build -r",
     "build-ts": "tsc",
     "build": "npm run build-rust && npm run build-ts",
-    "test": "mocha",
+    "test": "mocha ./dist/lib/test",
     "prepublishOnly": "npm install && npm run build && npm test"
   },
   "devDependencies": {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,4 +1,4 @@
-const path = require('path');
+import path from 'path';
 const bindings : any = require(path.join(__dirname, '../../native'));
 
 export { bindings };

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,36 +86,36 @@ export interface EncryptionResult {
     ciphertexts: Helgamalsegmented
 }
 
-function encrypt(encryptionKeyHex: string, secretHex: string): EncryptionResult {
-    const res = JSON.parse(bindings.ve_encrypt(encryptionKeyHex, secretHex));
+function encrypt(encryptionKey: Buffer, secret: Buffer): EncryptionResult {
+    const res = JSON.parse(bindings.ve_encrypt(encryptionKey.toString('hex'), secret.toString('hex')));
     const witness: Witness = Witness.fromPlain(res[0]);
     const ciphertexts: Helgamalsegmented = Helgamalsegmented.fromPlain(res[1]);
     return { witness, ciphertexts };
 }
 
-function decrypt(decryptionKeyHex: string, ciphertexts: Helgamalsegmented): string {
+function decrypt(decryptionKey: Buffer, ciphertexts: Helgamalsegmented): Buffer {
     const secretKeyHex: string = bindings.ve_decrypt(
-        decryptionKeyHex,
+        decryptionKey.toString('hex'),
         JSON.stringify(ciphertexts)
     );
-    return secretKeyHex.padStart(64, '0');
+    return Buffer.from(secretKeyHex.padStart(64, '0'), 'hex');
 }
 
-function prove(encryptionKeyHex: string, encryptionResult: EncryptionResult): Proof {
+function prove(encryptionKey: Buffer, encryptionResult: EncryptionResult): Proof {
     const proof = JSON.parse(
         bindings.ve_prove(
-            encryptionKeyHex,
+            encryptionKey.toString('hex'),
             JSON.stringify(encryptionResult.witness),
             JSON.stringify(encryptionResult.ciphertexts))
     );
     return Proof.fromPlain(proof);
 }
 
-function verify(proof: Proof, encryptionKeyHex: string, publicKeyHex: string, ciphertexts: Helgamalsegmented): boolean {
+function verify(proof: Proof, encryptionKey: Buffer, publicKey: Buffer, ciphertexts: Helgamalsegmented): boolean {
     return bindings.ve_verify(
         JSON.stringify(proof),
-        encryptionKeyHex,
-        publicKeyHex,
+        encryptionKey.toString('hex'),
+        publicKey.toString('hex'),
         JSON.stringify(ciphertexts));
 }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -4,44 +4,46 @@ import {ec as EC} from 'elliptic';
 const ec = new EC('secp256k1');
 
 describe('Test verifiable DL encryption', () => {
-    let decryptionKeyHex: string;
-    let encryptionKeyHex: string;
-    let secretKeyHex: string;
-    let publicKeyHex: string;
+    let decryptionKey: Buffer;
+    let encryptionKey: Buffer;
+    let secretKey: Buffer;
+    let publicKey: Buffer;
 
     before(() => {
         const encKeyPair = ec.genKeyPair();
-        decryptionKeyHex = encKeyPair
+        decryptionKey = encKeyPair
             .getPrivate()
-            .toBuffer()
-            .toString('hex');
-        encryptionKeyHex = encKeyPair
-            .getPublic()
-            .encode('hex', false)
-            .substr(2);  // (x,y)
+            .toBuffer();
+        encryptionKey = Buffer.from(
+            encKeyPair
+                .getPublic()
+                .encode('hex', false)
+                .substr(2), // (x,y)
+            'hex');
 
         const keyPair = ec.genKeyPair();
-        secretKeyHex = keyPair
+        secretKey = keyPair
             .getPrivate()
-            .toBuffer()
-            .toString('hex');
-        publicKeyHex = keyPair
-            .getPublic()
-            .encode('hex', false)
-            .substr(2);  // (x,y)
+            .toBuffer();
+        publicKey = Buffer.from(
+            keyPair
+                .getPublic()
+                .encode('hex', false)
+                .substr(2),  // (x,y)
+            'hex');
     });
 
     it('decrypt encryption', () => {
-        const { ciphertexts } = ve.encrypt(encryptionKeyHex, secretKeyHex);
-        const secretKeyHexNew = ve.decrypt(decryptionKeyHex, ciphertexts);
-        assert(secretKeyHexNew === secretKeyHex,
+        const { ciphertexts } = ve.encrypt(encryptionKey, secretKey);
+        const secretKeyNew = ve.decrypt(decryptionKey, ciphertexts);
+        assert(secretKeyNew.equals(secretKey),
             'value returned from decryption does not equal the encrypted secret');
     });
 
     it('prove encryption of discrete logarithm', () => {
-        const encryptionResult = ve.encrypt(encryptionKeyHex, secretKeyHex);
-        const proof = ve.prove(encryptionKeyHex, encryptionResult);
-        const isVerified = ve.verify(proof, encryptionKeyHex, publicKeyHex, encryptionResult.ciphertexts);
+        const encryptionResult = ve.encrypt(encryptionKey, secretKey);
+        const proof = ve.prove(encryptionKey, encryptionResult);
+        const isVerified = ve.verify(proof, encryptionKey, publicKey, encryptionResult.ciphertexts);
         assert(isVerified, "failed proof verification");
     });
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,6 +1,6 @@
 import ve from '../src';
 import assert from 'assert';
-const EC = require('elliptic').ec;
+import {ec as EC} from 'elliptic';
 const ec = new EC('secp256k1');
 
 describe('Test verifiable DL encryption', () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,13 +1,13 @@
-const {encrypt, decrypt, prove, verify} = require('../dist/src');
-const assert = require('assert');
+import ve from '../src';
+import assert from 'assert';
 const EC = require('elliptic').ec;
 const ec = new EC('secp256k1');
 
 describe('Test verifiable DL encryption', () => {
-    let decryptionKeyHex;
-    let encryptionKeyHex;
-    let secretKeyHex;
-    let publicKeyHex;
+    let decryptionKeyHex: string;
+    let encryptionKeyHex: string;
+    let secretKeyHex: string;
+    let publicKeyHex: string;
 
     before(() => {
         const encKeyPair = ec.genKeyPair();
@@ -32,17 +32,16 @@ describe('Test verifiable DL encryption', () => {
     });
 
     it('decrypt encryption', () => {
-        const { ciphertexts } = encrypt(encryptionKeyHex, secretKeyHex);
-        const secretKeyHexNew = decrypt(decryptionKeyHex, ciphertexts);
-        assert(typeof secretKeyHexNew === 'string');
+        const { ciphertexts } = ve.encrypt(encryptionKeyHex, secretKeyHex);
+        const secretKeyHexNew = ve.decrypt(decryptionKeyHex, ciphertexts);
         assert(secretKeyHexNew === secretKeyHex,
             'value returned from decryption does not equal the encrypted secret');
     });
 
     it('prove encryption of discrete logarithm', () => {
-        const { witness, ciphertexts } = encrypt(encryptionKeyHex, secretKeyHex);
-        const proof = prove(encryptionKeyHex, witness, ciphertexts);
-        const isVerified = verify(proof, encryptionKeyHex, publicKeyHex, ciphertexts);
+        const encryptionResult = ve.encrypt(encryptionKeyHex, secretKeyHex);
+        const proof = ve.prove(encryptionKeyHex, encryptionResult);
+        const isVerified = ve.verify(proof, encryptionKeyHex, publicKeyHex, encryptionResult.ciphertexts);
         assert(isVerified, "failed proof verification");
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,15 +3,16 @@
     /* Basic Options */
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     "declarationDir": "./dist/types",
-    "outDir": "./dist/src",
-    "rootDir": "./src",/* Redirect output structure to the directory. */
+    "outDir": "./dist/lib",
+    "rootDir": "./",/* Redirect output structure to the directory. */
     "composite": true,                     /* Enable project compilation */
     "strict": true,                           /* Enable all strict type-checking options. */
     "strictPropertyInitialization": false,
     "esModuleInterop": true                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
   },
   "include": [
-    "src"
+    "src",
+    "test"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
- Change API to use `Buffer` rather than strings
- Add API section in README.md.